### PR TITLE
don't create shims for unwanted helper programs

### DIFF
--- a/lftp/tools/chocolateyinstall.ps1
+++ b/lftp/tools/chocolateyinstall.ps1
@@ -4,4 +4,9 @@ $url64 = 'https://f001.backblazeb2.com/file/nwgat-cdn/lftp/win64/lftp-4.9.1.win6
 $checksum = 'A88A1A694A907CE7226836F8CB12A919'
 $checksum64 = '0C19C8DD3D296C8253116D4AD4877F79'
 $installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+out-file -filepath sh.exe.ignore  -InputObject ""
+out-file -filepath bash.exe.ignore  -InputObject ""
+out-file -filepath ssh.exe.ignore  -InputObject ""
+
 Install-ChocolateyZipPackage "$packageName" "$url" "$installDir" "$url64" $checksum


### PR DESCRIPTION
Please don't "pollute" my PATH with these versions of sh.exe/bash.exe/ssh.exe shims.
I only want lftp.exe and since they are still available in the `%ChocolateyInstall%\lib\lftp\bin` folder next to lftp.exe, it should still be able to find and use them. Thanks.